### PR TITLE
customizable parser

### DIFF
--- a/src/Encode.elm
+++ b/src/Encode.elm
@@ -56,7 +56,7 @@ import Types
 {-| An EDN element.
 -}
 type alias Element =
-    Types.Element
+    Types.Element ()
 
 
 {-| An EDN symbol.

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -11,7 +11,7 @@ import Dict exposing (Dict)
 
 {-| An EDN element
 -}
-type Element
+type Element a
     = Nil
     | Bool Bool
     | String String
@@ -22,8 +22,9 @@ type Element
     | BigInt { sign : String, digits : String }
     | Float Float
     | BigFloat { sign : String, digits : String } String { sign : String, digits : String }
-    | Set (List Element)
-    | List (List Element)
-    | Vector (List Element)
-    | Map (Dict String Element) (List ( Element, Element ))
-    | Tagged String Element
+    | Set (List (Element a))
+    | List (List (Element a))
+    | Vector (List (Element a))
+    | Map (Dict String (Element a)) (List ( Element a, Element a ))
+    | Tagged String (Element a)
+    | Custom a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,7 +10,7 @@ import Test exposing (..)
 import Types exposing (..)
 
 
-toMap : List ( Element, Element ) -> Element
+toMap : List ( Element a, Element a ) -> Element a
 toMap l =
     Map Dict.empty l
 
@@ -41,11 +41,11 @@ parseOk cs =
 
 
 element =
-    Parse.onlyElement
+    Parse.onlyElement (always Nothing)
 
 
 elements =
-    Parse.onlyElements
+    Parse.onlyElements (always Nothing)
 
 
 suite : Test


### PR DESCRIPTION
This extends the core `Parse` module to allow passing in custom tag handlers. That might allow for a less "context-dependent" API than the current `Decode`. That is, have users directly call

```
decode : Config a -> String -> Result String (Element a)
```

Not sure that's really a win though.
